### PR TITLE
[MVC 구현하기 - 1단계] 디우(김동규) 미션 제출합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@
   - [x] 어노테이션 기반으로 HTTP 메서드와 URL에 따라 컨트롤러를 매핑해줄 수 있다.
 - [x] DispatcherServlet에서 HandlerMapping 인터페이스를 활용하여 AnnotationHandlerMapping과 ManualHandlerMapping 둘다 처리할 수 있다.
   - [x] DispatcherServlet에서 instanceof 를 이용하여 두 가지 HandlerMapping 을 처리해준다.
-
+- [x] JspView 를 이용해서 redirect 혹은 forward 를 해줄 수 있다.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 ## 1단계 구현 내용 정리
 
-- [ ] AnnotationHandlerMappingTest가 정상 동작한다.
+- [x] AnnotationHandlerMappingTest가 정상 동작한다.
+  - [x] 어노테이션 기반으로 HTTP 메서드와 URL에 따라 컨트롤러를 매핑해줄 수 있다.
 - [ ] DispatcherServlet에서 HandlerMapping 인터페이스를 활용하여 AnnotationHandlerMapping과 ManualHandlerMapping 둘다 처리할 수 있다.
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # @MVC 구현하기
+
+---
+
+## 1단계 구현 내용 정리
+
+- [ ] AnnotationHandlerMappingTest가 정상 동작한다.
+- [ ] DispatcherServlet에서 HandlerMapping 인터페이스를 활용하여 AnnotationHandlerMapping과 ManualHandlerMapping 둘다 처리할 수 있다.
+

--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@
 
 - [x] AnnotationHandlerMappingTest가 정상 동작한다.
   - [x] 어노테이션 기반으로 HTTP 메서드와 URL에 따라 컨트롤러를 매핑해줄 수 있다.
-- [ ] DispatcherServlet에서 HandlerMapping 인터페이스를 활용하여 AnnotationHandlerMapping과 ManualHandlerMapping 둘다 처리할 수 있다.
+- [x] DispatcherServlet에서 HandlerMapping 인터페이스를 활용하여 AnnotationHandlerMapping과 ManualHandlerMapping 둘다 처리할 수 있다.
+  - [x] DispatcherServlet에서 instanceof 를 이용하여 두 가지 HandlerMapping 을 처리해준다.
 

--- a/app/src/main/java/com/techcourse/AppWebApplicationInitializer.java
+++ b/app/src/main/java/com/techcourse/AppWebApplicationInitializer.java
@@ -2,6 +2,7 @@ package com.techcourse;
 
 import jakarta.servlet.ServletContext;
 import nextstep.mvc.DispatcherServlet;
+import nextstep.mvc.controller.tobe.AnnotationHandlerMapping;
 import nextstep.web.WebApplicationInitializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,6 +15,7 @@ public class AppWebApplicationInitializer implements WebApplicationInitializer {
     public void onStartup(final ServletContext servletContext) {
         final var dispatcherServlet = new DispatcherServlet();
         dispatcherServlet.addHandlerMapping(new ManualHandlerMapping());
+        dispatcherServlet.addHandlerMapping(new AnnotationHandlerMapping());
 
         final var dispatcher = servletContext.addServlet("dispatcher", dispatcherServlet);
         dispatcher.setLoadOnStartup(1);

--- a/app/src/main/java/com/techcourse/AppWebApplicationInitializer.java
+++ b/app/src/main/java/com/techcourse/AppWebApplicationInitializer.java
@@ -15,7 +15,7 @@ public class AppWebApplicationInitializer implements WebApplicationInitializer {
     public void onStartup(final ServletContext servletContext) {
         final var dispatcherServlet = new DispatcherServlet();
         dispatcherServlet.addHandlerMapping(new ManualHandlerMapping());
-        dispatcherServlet.addHandlerMapping(new AnnotationHandlerMapping());
+        dispatcherServlet.addHandlerMapping(new AnnotationHandlerMapping("smaples"));
 
         final var dispatcher = servletContext.addServlet("dispatcher", dispatcherServlet);
         dispatcher.setLoadOnStartup(1);

--- a/mvc/src/main/java/nextstep/mvc/DispatcherServlet.java
+++ b/mvc/src/main/java/nextstep/mvc/DispatcherServlet.java
@@ -1,17 +1,22 @@
 package nextstep.mvc;
 
+import static nextstep.mvc.view.JspView.REDIRECT_PREFIX;
+
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import nextstep.mvc.controller.asis.Controller;
-import nextstep.mvc.view.JspView;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import nextstep.mvc.controller.asis.Controller;
+import nextstep.mvc.controller.tobe.HandlerExecution;
+import nextstep.mvc.controller.tobe.exception.NotSupportHandler;
+import nextstep.mvc.view.ModelAndView;
+import nextstep.mvc.view.View;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DispatcherServlet extends HttpServlet {
 
@@ -36,10 +41,28 @@ public class DispatcherServlet extends HttpServlet {
     @Override
     protected void service(final HttpServletRequest request, final HttpServletResponse response) throws ServletException {
         log.debug("Method : {}, Request URI : {}", request.getMethod(), request.getRequestURI());
+        final var handler = getHandler(request);
 
+        if (handler instanceof Controller) {
+            handleManualHandler(request, response, (Controller) handler);
+        }
+        if (handler instanceof HandlerExecution) {
+            handleAnnotationHandler(request, response, (HandlerExecution) handler);
+        }
+    }
+
+    private Object getHandler(final HttpServletRequest request) {
+        return handlerMappings.stream()
+                .map(handlerMapping -> handlerMapping.getHandler(request))
+                .filter(Objects::nonNull)
+                .findAny()
+                .orElseThrow(NotSupportHandler::new);
+    }
+
+    private void handleManualHandler(final HttpServletRequest request, final HttpServletResponse response,
+                                     final Controller handler) throws ServletException {
         try {
-            final var controller = getController(request);
-            final var viewName = controller.execute(request, response);
+            String viewName = handler.execute(request, response);
             move(viewName, request, response);
         } catch (Throwable e) {
             log.error("Exception : {}", e.getMessage(), e);
@@ -47,18 +70,22 @@ public class DispatcherServlet extends HttpServlet {
         }
     }
 
-    private Controller getController(final HttpServletRequest request) {
-        return handlerMappings.stream()
-                .map(handlerMapping -> handlerMapping.getHandler(request))
-                .filter(Objects::nonNull)
-                .map(Controller.class::cast)
-                .findFirst()
-                .orElseThrow();
+    private static void handleAnnotationHandler(final HttpServletRequest request, final HttpServletResponse response,
+                                  final HandlerExecution handler) {
+        try {
+            ModelAndView modelAndView = handler.handle(request, response);
+            final Map<String, Object> model = modelAndView.getModel();
+            final View view = modelAndView.getView();
+            view.render(model, request, response);
+        } catch (Exception e) {
+            log.error("Exception : {}", e.getMessage(), e);
+            throw new RuntimeException(e.getMessage());
+        }
     }
 
     private void move(final String viewName, final HttpServletRequest request, final HttpServletResponse response) throws Exception {
-        if (viewName.startsWith(JspView.REDIRECT_PREFIX)) {
-            response.sendRedirect(viewName.substring(JspView.REDIRECT_PREFIX.length()));
+        if (viewName.startsWith(REDIRECT_PREFIX)) {
+            response.sendRedirect(viewName.substring(REDIRECT_PREFIX.length()));
             return;
         }
 

--- a/mvc/src/main/java/nextstep/mvc/controller/tobe/AnnotationHandlerMapping.java
+++ b/mvc/src/main/java/nextstep/mvc/controller/tobe/AnnotationHandlerMapping.java
@@ -1,12 +1,18 @@
 package nextstep.mvc.controller.tobe;
 
 import jakarta.servlet.http.HttpServletRequest;
-import nextstep.mvc.HandlerMapping;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import nextstep.mvc.HandlerMapping;
+import nextstep.web.annotation.Controller;
+import nextstep.web.annotation.RequestMapping;
+import nextstep.web.support.RequestMethod;
+import org.reflections.Reflections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AnnotationHandlerMapping implements HandlerMapping {
 
@@ -25,6 +31,30 @@ public class AnnotationHandlerMapping implements HandlerMapping {
     }
 
     public Object getHandler(final HttpServletRequest request) {
-        return null;
+        for (Object o : basePackage) {
+            final Reflections reflections = new Reflections(o);
+            final Set<Class<?>> typesAnnotatedWith = reflections.getTypesAnnotatedWith(Controller.class);
+            log.info("{}", typesAnnotatedWith);
+
+            for (Class<?> aClass : typesAnnotatedWith) {
+                final Method[] declaredMethods = aClass.getDeclaredMethods();
+                for (Method declaredMethod : declaredMethods) {
+                    final RequestMapping requestMapping = declaredMethod.getAnnotation(RequestMapping.class);
+                    if (requestMapping != null) {
+                        final HandlerKey handlerKey = new HandlerKey(requestMapping.value(),
+                                RequestMethod.valueOf(requestMapping.method()[0].name()));
+                        final Object handler;
+                        try {
+                            handler = declaredMethod.getDeclaringClass().getConstructor().newInstance();
+                        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                            throw new RuntimeException("매핑 가능한 핸들러가 존재하지 않습니다.");
+                        }
+                        handlerExecutions.put(handlerKey, new HandlerExecution(handler, declaredMethod));
+                    }
+                }
+            }
+        }
+
+        return handlerExecutions.get(new HandlerKey(request.getRequestURI(), RequestMethod.valueOf(request.getMethod())));
     }
 }

--- a/mvc/src/main/java/nextstep/mvc/controller/tobe/AnnotationHandlerMapping.java
+++ b/mvc/src/main/java/nextstep/mvc/controller/tobe/AnnotationHandlerMapping.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import nextstep.mvc.HandlerMapping;
+import nextstep.mvc.controller.tobe.exception.NotSupportHandler;
 import nextstep.web.annotation.Controller;
 import nextstep.web.annotation.RequestMapping;
 import nextstep.web.support.RequestMethod;
@@ -17,44 +18,66 @@ import org.slf4j.LoggerFactory;
 public class AnnotationHandlerMapping implements HandlerMapping {
 
     private static final Logger log = LoggerFactory.getLogger(AnnotationHandlerMapping.class);
+    private static final int METHOD_INDEX = 0;
 
-    private final Object[] basePackage;
+    private final String[] basePackage;
     private final Map<HandlerKey, HandlerExecution> handlerExecutions;
 
-    public AnnotationHandlerMapping(final Object... basePackage) {
+    public AnnotationHandlerMapping(final String... basePackage) {
         this.basePackage = basePackage;
         this.handlerExecutions = new HashMap<>();
     }
 
     public void initialize() {
         log.info("Initialized AnnotationHandlerMapping!");
+        initHandlerExecution(basePackage);
     }
 
     public Object getHandler(final HttpServletRequest request) {
-        for (Object o : basePackage) {
-            final Reflections reflections = new Reflections(o);
-            final Set<Class<?>> typesAnnotatedWith = reflections.getTypesAnnotatedWith(Controller.class);
-            log.info("{}", typesAnnotatedWith);
+        return handlerExecutions.get(
+                new HandlerKey(request.getRequestURI(), RequestMethod.valueOf(request.getMethod())));
+    }
 
-            for (Class<?> aClass : typesAnnotatedWith) {
-                final Method[] declaredMethods = aClass.getDeclaredMethods();
-                for (Method declaredMethod : declaredMethods) {
-                    final RequestMapping requestMapping = declaredMethod.getAnnotation(RequestMapping.class);
-                    if (requestMapping != null) {
-                        final HandlerKey handlerKey = new HandlerKey(requestMapping.value(),
-                                RequestMethod.valueOf(requestMapping.method()[0].name()));
-                        final Object handler;
-                        try {
-                            handler = declaredMethod.getDeclaringClass().getConstructor().newInstance();
-                        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-                            throw new RuntimeException("매핑 가능한 핸들러가 존재하지 않습니다.");
-                        }
-                        handlerExecutions.put(handlerKey, new HandlerExecution(handler, declaredMethod));
-                    }
-                }
-            }
+    private void initHandlerExecution(final Object[] basePackage) {
+        final Reflections reflections = new Reflections(basePackage);
+        final Set<Class<?>> controllers = getAllControllers(reflections);
+
+        for (Class<?> controllerClass : controllers) {
+            final Method[] methods = controllerClass.getDeclaredMethods();
+            putSupportedMethodInHandlerExecution(methods);
         }
+    }
 
-        return handlerExecutions.get(new HandlerKey(request.getRequestURI(), RequestMethod.valueOf(request.getMethod())));
+    private static Set<Class<?>> getAllControllers(final Reflections reflections) {
+        return reflections.getTypesAnnotatedWith(Controller.class);
+    }
+
+    private void putSupportedMethodInHandlerExecution(final Method[] methods) {
+        for (Method method : methods) {
+            final RequestMapping requestMapping = method.getAnnotation(RequestMapping.class);
+            putHandlerExecution(method, requestMapping);
+        }
+    }
+
+    private void putHandlerExecution(final Method method, final RequestMapping requestMapping) {
+        if (requestMapping != null) {
+            final HandlerKey handlerKey = getHandlerKey(requestMapping);
+            final Object handler = getHandler(method);
+            handlerExecutions.put(handlerKey, new HandlerExecution(handler, method));
+        }
+    }
+
+    private static HandlerKey getHandlerKey(final RequestMapping requestMapping) {
+        return new HandlerKey(requestMapping.value(),
+                RequestMethod.valueOf(requestMapping.method()[METHOD_INDEX].name()));
+    }
+
+    private static Object getHandler(final Method method) {
+        try {
+            return method.getDeclaringClass().getConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
+                 NoSuchMethodException e) {
+            throw new NotSupportHandler();
+        }
     }
 }

--- a/mvc/src/main/java/nextstep/mvc/controller/tobe/HandlerExecution.java
+++ b/mvc/src/main/java/nextstep/mvc/controller/tobe/HandlerExecution.java
@@ -2,11 +2,20 @@ package nextstep.mvc.controller.tobe;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.Method;
 import nextstep.mvc.view.ModelAndView;
 
 public class HandlerExecution {
 
+    private final Object handler;
+    private final Method method;
+
+    public HandlerExecution(final Object handler, final Method method) {
+        this.handler = handler;
+        this.method = method;
+    }
+
     public ModelAndView handle(final HttpServletRequest request, final HttpServletResponse response) throws Exception {
-        return null;
+        return (ModelAndView) method.invoke(handler, request, response);
     }
 }

--- a/mvc/src/main/java/nextstep/mvc/controller/tobe/exception/NotSupportHandler.java
+++ b/mvc/src/main/java/nextstep/mvc/controller/tobe/exception/NotSupportHandler.java
@@ -1,0 +1,8 @@
+package nextstep.mvc.controller.tobe.exception;
+
+public class NotSupportHandler extends RuntimeException {
+
+    public NotSupportHandler() {
+        super("매핑 가능한 핸들러가 존재하지 않습니다.");
+    }
+}

--- a/mvc/src/main/java/nextstep/mvc/view/JspView.java
+++ b/mvc/src/main/java/nextstep/mvc/view/JspView.java
@@ -10,21 +10,27 @@ import java.util.Map;
 public class JspView implements View {
 
     private static final Logger log = LoggerFactory.getLogger(JspView.class);
+    private static final String REDIRECT_PREFIX = "redirect:";
 
-    public static final String REDIRECT_PREFIX = "redirect:";
+    private final String viewName;
 
     public JspView(final String viewName) {
+        this.viewName = viewName;
     }
 
     @Override
     public void render(final Map<String, ?> model, final HttpServletRequest request, final HttpServletResponse response) throws Exception {
-        // todo
+        if (viewName.startsWith(REDIRECT_PREFIX)) {
+            response.sendRedirect(viewName.substring(REDIRECT_PREFIX.length()));
+            return;
+        }
 
         model.keySet().forEach(key -> {
             log.debug("attribute name : {}, value : {}", key, model.get(key));
             request.setAttribute(key, model.get(key));
         });
 
-        // todo
+        final var requestDispatcher = request.getRequestDispatcher(viewName);
+        requestDispatcher.forward(request, response);
     }
 }

--- a/mvc/src/test/java/nextstep/mvc/DispatcherServletTest.java
+++ b/mvc/src/test/java/nextstep/mvc/DispatcherServletTest.java
@@ -3,10 +3,14 @@ package nextstep.mvc;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import nextstep.mvc.controller.tobe.AnnotationHandlerMapping;
 import nextstep.mvc.controller.tobe.exception.NotSupportHandler;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,15 +31,19 @@ class DispatcherServletTest {
 
     @DisplayName("Controller 인터페이스를 상속한 핸들러 뿐 아니라 어노테이션 기반의 핸들러를 지원한다.")
     @Test
-    void getHandler() {
+    void getHandler() throws ServletException, IOException {
         final var request = mock(HttpServletRequest.class);
         final var response = mock(HttpServletResponse.class);
+        final RequestDispatcher requestDispatcher = mock(RequestDispatcher.class);
 
+        when(request.getRequestDispatcher(""))
+                .thenReturn(requestDispatcher);
         when(request.getAttribute("id")).thenReturn("dwoo");
         when(request.getRequestURI()).thenReturn("/get-test");
         when(request.getMethod()).thenReturn("GET");
 
         assertDoesNotThrow(() -> dispatcherServlet.service(request, response));
+        verify(requestDispatcher).forward(request, response);
     }
 
     @DisplayName("지원하지 않는 핸들러에 대해서는 예외가 발생한다.")

--- a/mvc/src/test/java/nextstep/mvc/DispatcherServletTest.java
+++ b/mvc/src/test/java/nextstep/mvc/DispatcherServletTest.java
@@ -1,0 +1,53 @@
+package nextstep.mvc;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import nextstep.mvc.controller.tobe.AnnotationHandlerMapping;
+import nextstep.mvc.controller.tobe.exception.NotSupportHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DispatcherServletTest {
+
+    private DispatcherServlet dispatcherServlet;
+
+    @BeforeEach
+    void setUp() {
+        final HandlerMapping annotationHandlerMapping = new AnnotationHandlerMapping("samples");
+        dispatcherServlet = new DispatcherServlet();
+        dispatcherServlet.addHandlerMapping(annotationHandlerMapping);
+        dispatcherServlet.init();
+    }
+
+    @DisplayName("Controller 인터페이스를 상속한 핸들러 뿐 아니라 어노테이션 기반의 핸들러를 지원한다.")
+    @Test
+    void getHandler() {
+        final var request = mock(HttpServletRequest.class);
+        final var response = mock(HttpServletResponse.class);
+
+        when(request.getAttribute("id")).thenReturn("dwoo");
+        when(request.getRequestURI()).thenReturn("/get-test");
+        when(request.getMethod()).thenReturn("GET");
+
+        assertDoesNotThrow(() -> dispatcherServlet.service(request, response));
+    }
+
+    @DisplayName("지원하지 않는 핸들러에 대해서는 예외가 발생한다.")
+    @Test
+    void invalidRequest() {
+        final var request = mock(HttpServletRequest.class);
+        final var response = mock(HttpServletResponse.class);
+
+        when(request.getRequestURI()).thenReturn("/get-invalid");
+        when(request.getMethod()).thenReturn("GET");
+
+        assertThatThrownBy(() -> dispatcherServlet.service(request, response))
+                .isInstanceOf(NotSupportHandler.class);
+    }
+}

--- a/mvc/src/test/java/nextstep/mvc/controller/tobe/AnnotationHandlerMappingTest.java
+++ b/mvc/src/test/java/nextstep/mvc/controller/tobe/AnnotationHandlerMappingTest.java
@@ -51,4 +51,20 @@ class AnnotationHandlerMappingTest {
 
         assertThat(modelAndView.getObject("id")).isEqualTo("gugu");
     }
+
+    @DisplayName("하나의 URL에 대한 여러 HTTP 메소드를 지원한다.")
+    @Test
+    void supportMultipleMethod() throws Exception {
+        final var request = mock(HttpServletRequest.class);
+        final var response = mock(HttpServletResponse.class);
+
+        when(request.getAttribute("id")).thenReturn("gugu");
+        when(request.getRequestURI()).thenReturn("/multiple-method-test");
+        when(request.getMethod()).thenReturn("POST");
+
+        final var handlerExecution = (HandlerExecution) handlerMapping.getHandler(request);
+        final var modelAndView = handlerExecution.handle(request, response);
+
+        assertThat(modelAndView.getObject("id")).isEqualTo("gugu");
+    }
 }

--- a/mvc/src/test/java/nextstep/mvc/controller/tobe/AnnotationHandlerMappingTest.java
+++ b/mvc/src/test/java/nextstep/mvc/controller/tobe/AnnotationHandlerMappingTest.java
@@ -1,13 +1,14 @@
 package nextstep.mvc.controller.tobe;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 class AnnotationHandlerMappingTest {
 
@@ -19,6 +20,7 @@ class AnnotationHandlerMappingTest {
         handlerMapping.initialize();
     }
 
+    @DisplayName("GET 메소드 요청에 대해서 어노테이션 기반의 핸들러를 찾을 수 있다.")
     @Test
     void get() throws Exception {
         final var request = mock(HttpServletRequest.class);
@@ -34,6 +36,7 @@ class AnnotationHandlerMappingTest {
         assertThat(modelAndView.getObject("id")).isEqualTo("gugu");
     }
 
+    @DisplayName("POST 메소드 요청에 대해서 어노테이션 기반의 핸들러를 찾을 수 있다.")
     @Test
     void post() throws Exception {
         final var request = mock(HttpServletRequest.class);

--- a/mvc/src/test/java/nextstep/mvc/view/JspViewTest.java
+++ b/mvc/src/test/java/nextstep/mvc/view/JspViewTest.java
@@ -19,8 +19,8 @@ class JspViewTest {
     @DisplayName("redirect를 할 수 있다.")
     @Test
     void redirect() {
-        HttpServletRequest request = mock(HttpServletRequest.class);
-        HttpServletResponse response = mock(HttpServletResponse.class);
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
 
         when(request.getRequestURI()).thenReturn("/");
         when(request.getMethod()).thenReturn("GET");
@@ -33,9 +33,9 @@ class JspViewTest {
     @DisplayName("requestDispatcher를 이용해 forward 해줄 수 있다.")
     @Test
     void forward() throws ServletException, IOException {
-        HttpServletRequest request = mock(HttpServletRequest.class);
-        HttpServletResponse response = mock(HttpServletResponse.class);
-        RequestDispatcher requestDispatcher = mock(RequestDispatcher.class);
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        final RequestDispatcher requestDispatcher = mock(RequestDispatcher.class);
 
         when(request.getRequestDispatcher("/index.jsp"))
                 .thenReturn(requestDispatcher);

--- a/mvc/src/test/java/nextstep/mvc/view/JspViewTest.java
+++ b/mvc/src/test/java/nextstep/mvc/view/JspViewTest.java
@@ -1,0 +1,48 @@
+package nextstep.mvc.view;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class JspViewTest {
+
+    @DisplayName("redirect를 할 수 있다.")
+    @Test
+    void redirect() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        when(request.getRequestURI()).thenReturn("/");
+        when(request.getMethod()).thenReturn("GET");
+
+        final JspView jspView = new JspView("redirect:/");
+
+        assertDoesNotThrow(() -> jspView.render(Map.of(), request, response));
+    }
+
+    @DisplayName("requestDispatcher를 이용해 forward 해줄 수 있다.")
+    @Test
+    void forward() throws ServletException, IOException {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        RequestDispatcher requestDispatcher = mock(RequestDispatcher.class);
+
+        when(request.getRequestDispatcher("/index.jsp"))
+                .thenReturn(requestDispatcher);
+
+        final JspView jspView = new JspView("/index.jsp");
+
+        assertDoesNotThrow(() -> jspView.render(Map.of(), request, response));
+        verify(requestDispatcher).forward(request, response);
+    }
+}

--- a/mvc/src/test/java/samples/TestController.java
+++ b/mvc/src/test/java/samples/TestController.java
@@ -18,7 +18,7 @@ public class TestController {
     @RequestMapping(value = "/get-test", method = RequestMethod.GET)
     public ModelAndView findUserId(final HttpServletRequest request, final HttpServletResponse response) {
         log.info("test controller get method");
-        final var modelAndView = new ModelAndView(new JspView(""));
+        final var modelAndView = new ModelAndView(new JspView("redirect:/"));
         modelAndView.addObject("id", request.getAttribute("id"));
         return modelAndView;
     }
@@ -26,7 +26,7 @@ public class TestController {
     @RequestMapping(value = "/post-test", method = RequestMethod.POST)
     public ModelAndView save(final HttpServletRequest request, final HttpServletResponse response) {
         log.info("test controller post method");
-        final var modelAndView = new ModelAndView(new JspView(""));
+        final var modelAndView = new ModelAndView(new JspView("redirect:/"));
         modelAndView.addObject("id", request.getAttribute("id"));
         return modelAndView;
     }

--- a/mvc/src/test/java/samples/TestController.java
+++ b/mvc/src/test/java/samples/TestController.java
@@ -1,12 +1,14 @@
 package samples;
 
+import static nextstep.web.support.RequestMethod.GET;
+import static nextstep.web.support.RequestMethod.POST;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import nextstep.mvc.view.JspView;
 import nextstep.mvc.view.ModelAndView;
 import nextstep.web.annotation.Controller;
 import nextstep.web.annotation.RequestMapping;
-import nextstep.web.support.RequestMethod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,7 +17,7 @@ public class TestController {
 
     private static final Logger log = LoggerFactory.getLogger(TestController.class);
 
-    @RequestMapping(value = "/get-test", method = RequestMethod.GET)
+    @RequestMapping(value = "/get-test", method = GET)
     public ModelAndView findUserId(final HttpServletRequest request, final HttpServletResponse response) {
         log.info("test controller get method");
         final var modelAndView = new ModelAndView(new JspView(""));
@@ -23,9 +25,17 @@ public class TestController {
         return modelAndView;
     }
 
-    @RequestMapping(value = "/post-test", method = RequestMethod.POST)
+    @RequestMapping(value = "/post-test", method = POST)
     public ModelAndView save(final HttpServletRequest request, final HttpServletResponse response) {
         log.info("test controller post method");
+        final var modelAndView = new ModelAndView(new JspView(""));
+        modelAndView.addObject("id", request.getAttribute("id"));
+        return modelAndView;
+    }
+
+    @RequestMapping(value = "/multiple-method-test", method = {GET, POST})
+    public ModelAndView supportMultipleMethod(final HttpServletRequest request, final HttpServletResponse response) {
+        log.info("test support multiple method");
         final var modelAndView = new ModelAndView(new JspView(""));
         modelAndView.addObject("id", request.getAttribute("id"));
         return modelAndView;

--- a/mvc/src/test/java/samples/TestController.java
+++ b/mvc/src/test/java/samples/TestController.java
@@ -18,7 +18,7 @@ public class TestController {
     @RequestMapping(value = "/get-test", method = RequestMethod.GET)
     public ModelAndView findUserId(final HttpServletRequest request, final HttpServletResponse response) {
         log.info("test controller get method");
-        final var modelAndView = new ModelAndView(new JspView("redirect:/"));
+        final var modelAndView = new ModelAndView(new JspView(""));
         modelAndView.addObject("id", request.getAttribute("id"));
         return modelAndView;
     }
@@ -26,7 +26,7 @@ public class TestController {
     @RequestMapping(value = "/post-test", method = RequestMethod.POST)
     public ModelAndView save(final HttpServletRequest request, final HttpServletResponse response) {
         log.info("test controller post method");
-        final var modelAndView = new ModelAndView(new JspView("redirect:/"));
+        final var modelAndView = new ModelAndView(new JspView(""));
         modelAndView.addObject("id", request.getAttribute("id"));
         return modelAndView;
     }


### PR DESCRIPTION
안녕하세요, 수달!!🦦 디우입니다.😃

이번 미션을 진행하면서 이전에 공부하였던, 스프링 MVC 구조를 다시 한 번 상기시켜보는 기회가 되었습니다!!
특히, 스프링을 사용하면서 항상 궁금하였던 어노테이션 기반의 매핑 과정을, 리플렉션을 이용해서 직접 구현해보는 경험은 매우 새로웠던 것 같아요!! ㅎ.ㅎ
이외에도 `JspViewTest` 에서 mocking 을 잘 몰라서 발생하는 문제도 해결하며 다시 한 번 학습하는 기회가 되었습니다!

이번 미션에서는 Adapter 를 사용하지 않고, 분기문을 사용해서 Annotation 기반의 Handler 를 지원해주도록 구현하였습니다!
(2단계 미션(점진적인 리팩터링)을 진행하면서 기존 코드에서 Adapter 를 사용하는 방향으로 개선할 기회가 있을 것 같아 이와 같이 구현하였습니다..!!)

---

## 구현 기능 목록(구현 내용)

**1. AnnotationHandlerMapping**

리플렉션을 사용해서 basePackage 하위에 있는 `Controller` 어노테이션 클래스들을 찾아오도록 하였습니다.
이후 해당 클래스들의 메소드들 중 `RequestMapping` 어노테이션이 붙은 메소드들로 `HandlerExecution` 을 생성해 등록함으로써 어노테이션 기반의 핸들러를 지원해주도록 구현하였습니다!

**2. AnnotationhandlerMapping & ManualHandlerMapping 지원**

`DispatcherServlet` 에서 등록된 `handlerMapping` 에 대해서 `instanceof` 키워드로 `Controller` 인터페이스를 구현하고 있는지, `HandlerExecution` 인지에 따라 분기해줌으로써 기존 `ManualHandlerMapping` 이외에도 `smaples` basePackage 하위에 있는 어노테이션 기반의 핸들러를 매핑해줄 수 있도록 구현하였습니다. 별도의 컨트롤러를 프로덕션 코드에 추가하지는 않고, 테스트 코드를 통해서 `DispatcherServlet` 이 어노테이션 기반의 핸들러를 지원해주는지 확인해주었습니다. 

**3. JspView**

체크리스트에 있는 사항은 아니었지만, 힌트에 `JspView는 어떻게 구현 할 수 있을까?` 와 같은 내용이 있어서 JspView 도 함께 구현하고 테스트도 진행해주었습니다! JspView 로 redirect와 forward에 대한 책임이 분리되면서 `DispatcherServlet` 에서는 기존의 `move()` 메소드를 제거해주었습니다!

---

## 체크 리스트

- [x] AnnotationHandlerMappingTest가 정상 동작한다.
- [x] DispatcherServlet에서 HandlerMapping 인터페이스를 활용하여 AnnotationHandlerMapping과 ManualHandlerMapping 둘다 처리할 수 있다.

---

잘 부탁드립니다!!🙂