### PR TITLE
[MVC 구현하기 - 1단계] 우가(윤정욱) 미션 제출합니다.

### DIFF
--- a/mvc/src/main/java/webmvc/org/springframework/web/servlet/mvc/tobe/AnnotationHandlerMapping.java
+++ b/mvc/src/main/java/webmvc/org/springframework/web/servlet/mvc/tobe/AnnotationHandlerMapping.java
@@ -1,11 +1,20 @@
 package webmvc.org.springframework.web.servlet.mvc.tobe;
 
+import context.org.springframework.stereotype.Controller;
 import jakarta.servlet.http.HttpServletRequest;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
-import java.util.Map;
+import web.org.springframework.web.bind.annotation.RequestMapping;
+import web.org.springframework.web.bind.annotation.RequestMethod;
 
 public class AnnotationHandlerMapping {
 
@@ -21,9 +30,56 @@ public class AnnotationHandlerMapping {
 
     public void initialize() {
         log.info("Initialized AnnotationHandlerMapping!");
+        Reflections reflections = new Reflections(basePackage);
+
+        Set<Class<?>> controllerClasses = reflections.getTypesAnnotatedWith(Controller.class);
+
+        for (Class<?> controllerClass : controllerClasses) {
+            final List<Method> declaredMethods = getDeclaredRequestMapping(controllerClass);
+            addHandlerExecution(controllerClass, declaredMethods);
+        }
+    }
+
+    private List<Method> getDeclaredRequestMapping(final Class<?> controllerClass) {
+        final Method[] methods = controllerClass.getMethods();
+        return Arrays.stream(methods)
+                .filter(method -> method.isAnnotationPresent(RequestMapping.class))
+                .collect(Collectors.toList());
+    }
+
+    private void addHandlerExecution(final Class<?> controllerClass, final List<Method> declaredMethods) {
+        final String rootPath = getRootPath(controllerClass);
+        for (Method declaredMethod : declaredMethods) {
+            final List<HandlerKey> handlerKeys = getHandlerKeys(rootPath, declaredMethod);
+            final HandlerExecution handlerExecution = getHandlerExecution(controllerClass, declaredMethod);
+            handlerKeys.forEach(key -> handlerExecutions.put(key, handlerExecution));
+        }
+    }
+
+    private HandlerExecution getHandlerExecution(final Class<?> controllerClass, final Method declaredMethod) {
+        try {
+            return HandlerExecution.of(controllerClass, declaredMethod);
+        } catch (Exception e) {
+            throw new NoSuchElementException("Class 를 확인해주세요.");
+        }
+    }
+
+    private String getRootPath(final Class<?> controllerClass) {
+        return controllerClass.getAnnotation(Controller.class).path();
+    }
+
+    private List<HandlerKey> getHandlerKeys(final String rootPath, final Method declaredMethod) {
+        final RequestMapping requestMappingAnnotation = declaredMethod.getAnnotation(RequestMapping.class);
+
+        return Arrays.stream(requestMappingAnnotation.method())
+                .map(requestMethod -> new HandlerKey(rootPath + requestMappingAnnotation.value(), requestMethod))
+                .collect(Collectors.toList());
     }
 
     public Object getHandler(final HttpServletRequest request) {
-        return null;
+        final HandlerKey handlerKeyByRequest = new HandlerKey(request.getRequestURI(),
+                RequestMethod.valueOf(request.getMethod()));
+
+        return handlerExecutions.get(handlerKeyByRequest);
     }
 }

--- a/mvc/src/main/java/webmvc/org/springframework/web/servlet/mvc/tobe/HandlerExecution.java
+++ b/mvc/src/main/java/webmvc/org/springframework/web/servlet/mvc/tobe/HandlerExecution.java
@@ -2,11 +2,24 @@ package webmvc.org.springframework.web.servlet.mvc.tobe;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.Method;
 import webmvc.org.springframework.web.servlet.ModelAndView;
 
 public class HandlerExecution {
 
+    private final Object executor;
+    private final Method handlerMethod;
+
+    private HandlerExecution(final Object executor, final Method handlerMethod) {
+        this.executor = executor;
+        this.handlerMethod = handlerMethod;
+    }
+
+    public static HandlerExecution of(final Class<?> executor, final Method handlerMethod) throws Exception {
+        return new HandlerExecution(executor.getConstructor().newInstance(), handlerMethod);
+    }
+
     public ModelAndView handle(final HttpServletRequest request, final HttpServletResponse response) throws Exception {
-        return null;
+        return (ModelAndView) handlerMethod.invoke(executor, request, response);
     }
 }

--- a/mvc/src/test/java/webmvc/org/springframework/web/servlet/mvc/tobe/AnnotationHandlerMappingTest.java
+++ b/mvc/src/test/java/webmvc/org/springframework/web/servlet/mvc/tobe/AnnotationHandlerMappingTest.java
@@ -1,13 +1,13 @@
 package webmvc.org.springframework.web.servlet.mvc.tobe;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class AnnotationHandlerMappingTest {
 

--- a/study/src/main/java/servlet/com/example/CharacterEncodingFilter.java
+++ b/study/src/main/java/servlet/com/example/CharacterEncodingFilter.java
@@ -11,6 +11,7 @@ public class CharacterEncodingFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         request.getServletContext().log("doFilter() 호출");
+        response.setCharacterEncoding("utf-8");
         chain.doFilter(request, response);
     }
 }

--- a/study/src/test/java/reflection/Junit3TestRunner.java
+++ b/study/src/test/java/reflection/Junit3TestRunner.java
@@ -1,5 +1,6 @@
 package reflection;
 
+import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
 
 class Junit3TestRunner {
@@ -7,7 +8,10 @@ class Junit3TestRunner {
     @Test
     void run() throws Exception {
         Class<Junit3Test> clazz = Junit3Test.class;
+        final Junit3Test junit3Test = clazz.getConstructor().newInstance();
 
-        // TODO Junit3Test에서 test로 시작하는 메소드 실행
+        for (final Method declaredMethod : clazz.getDeclaredMethods()) {
+            declaredMethod.invoke(junit3Test);
+        }
     }
 }

--- a/study/src/test/java/reflection/Junit4TestRunner.java
+++ b/study/src/test/java/reflection/Junit4TestRunner.java
@@ -1,5 +1,6 @@
 package reflection;
 
+import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
 
 class Junit4TestRunner {
@@ -7,7 +8,12 @@ class Junit4TestRunner {
     @Test
     void run() throws Exception {
         Class<Junit4Test> clazz = Junit4Test.class;
+        final Junit4Test junit4Test = clazz.getConstructor().newInstance();
 
-        // TODO Junit4Test에서 @MyTest 애노테이션이 있는 메소드 실행
+        for (final Method declaredMethod : clazz.getDeclaredMethods()) {
+            if (declaredMethod.isAnnotationPresent(MyTest.class)) {
+                declaredMethod.invoke(junit4Test);
+            }
+        }
     }
 }

--- a/study/src/test/java/reflection/ReflectionTest.java
+++ b/study/src/test/java/reflection/ReflectionTest.java
@@ -1,15 +1,17 @@
 package reflection;
 
-import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class ReflectionTest {
 
@@ -19,25 +21,27 @@ class ReflectionTest {
     void givenObject_whenGetsClassName_thenCorrect() {
         final Class<Question> clazz = Question.class;
 
-        assertThat(clazz.getSimpleName()).isEqualTo("");
-        assertThat(clazz.getName()).isEqualTo("");
-        assertThat(clazz.getCanonicalName()).isEqualTo("");
+        assertThat(clazz.getSimpleName()).isEqualTo("Question");
+        assertThat(clazz.getName()).isEqualTo("reflection.Question");
+        assertThat(clazz.getCanonicalName()).isEqualTo("reflection.Question");
     }
 
     @Test
     void givenClassName_whenCreatesObject_thenCorrect() throws ClassNotFoundException {
         final Class<?> clazz = Class.forName("reflection.Question");
 
-        assertThat(clazz.getSimpleName()).isEqualTo("");
-        assertThat(clazz.getName()).isEqualTo("");
-        assertThat(clazz.getCanonicalName()).isEqualTo("");
+        assertThat(clazz.getSimpleName()).isEqualTo("Question");
+        assertThat(clazz.getName()).isEqualTo("reflection.Question");
+        assertThat(clazz.getCanonicalName()).isEqualTo("reflection.Question");
     }
 
     @Test
     void givenObject_whenGetsFieldNamesAtRuntime_thenCorrect() {
         final Object student = new Student();
-        final Field[] fields = null;
-        final List<String> actualFieldNames = null;
+        final Field[] fields = student.getClass().getDeclaredFields();
+        final List<String> actualFieldNames = Arrays.stream(fields)
+                .map(Field::getName)
+                .collect(Collectors.toList());
 
         assertThat(actualFieldNames).contains("name", "age");
     }
@@ -45,8 +49,10 @@ class ReflectionTest {
     @Test
     void givenClass_whenGetsMethods_thenCorrect() {
         final Class<?> animalClass = Student.class;
-        final Method[] methods = null;
-        final List<String> actualMethods = null;
+        final Method[] methods = animalClass.getDeclaredMethods();
+        final List<String> actualMethods = Arrays.stream(methods)
+                .map(Method::getName)
+                .collect(Collectors.toList());
 
         assertThat(actualMethods)
                 .hasSize(3)
@@ -56,7 +62,7 @@ class ReflectionTest {
     @Test
     void givenClass_whenGetsAllConstructors_thenCorrect() {
         final Class<?> questionClass = Question.class;
-        final Constructor<?>[] constructors = null;
+        final Constructor<?>[] constructors = questionClass.getConstructors();
 
         assertThat(constructors).hasSize(2);
     }
@@ -65,11 +71,13 @@ class ReflectionTest {
     void givenClass_whenInstantiatesObjectsAtRuntime_thenCorrect() throws Exception {
         final Class<?> questionClass = Question.class;
 
-        final Constructor<?> firstConstructor = null;
-        final Constructor<?> secondConstructor = null;
+        final Constructor<?> firstConstructor = questionClass.getConstructor(String.class, String.class, String.class);
+        final Constructor<?> secondConstructor = questionClass.getConstructor(long.class, String.class, String.class,
+                String.class, Date.class, int.class);
 
-        final Question firstQuestion = null;
-        final Question secondQuestion = null;
+        final Question firstQuestion = (Question) firstConstructor.newInstance("gugu", "제목1", "내용1");
+        final Question secondQuestion = (Question) secondConstructor.newInstance(0L, "gugu", "제목2", "내용2", new Date(),
+                0);
 
         assertThat(firstQuestion.getWriter()).isEqualTo("gugu");
         assertThat(firstQuestion.getTitle()).isEqualTo("제목1");
@@ -82,7 +90,7 @@ class ReflectionTest {
     @Test
     void givenClass_whenGetsPublicFields_thenCorrect() {
         final Class<?> questionClass = Question.class;
-        final Field[] fields = null;
+        final Field[] fields = questionClass.getFields();
 
         assertThat(fields).hasSize(0);
     }
@@ -90,7 +98,7 @@ class ReflectionTest {
     @Test
     void givenClass_whenGetsDeclaredFields_thenCorrect() {
         final Class<?> questionClass = Question.class;
-        final Field[] fields = null;
+        final Field[] fields = questionClass.getDeclaredFields();
 
         assertThat(fields).hasSize(6);
         assertThat(fields[0].getName()).isEqualTo("questionId");
@@ -99,7 +107,7 @@ class ReflectionTest {
     @Test
     void givenClass_whenGetsFieldsByName_thenCorrect() throws Exception {
         final Class<?> questionClass = Question.class;
-        final Field field = null;
+        final Field field = questionClass.getDeclaredField("questionId");
 
         assertThat(field.getName()).isEqualTo("questionId");
     }
@@ -107,7 +115,7 @@ class ReflectionTest {
     @Test
     void givenClassField_whenGetsType_thenCorrect() throws Exception {
         final Field field = Question.class.getDeclaredField("questionId");
-        final Class<?> fieldClass = null;
+        final Class<?> fieldClass = field.getType();
 
         assertThat(fieldClass.getSimpleName()).isEqualTo("long");
     }
@@ -115,15 +123,15 @@ class ReflectionTest {
     @Test
     void givenClassField_whenSetsAndGetsValue_thenCorrect() throws Exception {
         final Class<?> studentClass = Student.class;
-        final Student student = null;
-        final Field field = null;
+        final Student student = (Student) studentClass.getConstructor().newInstance();
+        final Field field = student.getClass().getDeclaredField("age");
 
-        // todo field에 접근 할 수 있도록 만든다.
+        field.setAccessible(true);
 
         assertThat(field.getInt(student)).isZero();
         assertThat(student.getAge()).isZero();
 
-        field.set(null, null);
+        field.set(student, 99);
 
         assertThat(field.getInt(student)).isEqualTo(99);
         assertThat(student.getAge()).isEqualTo(99);

--- a/study/src/test/java/reflection/ReflectionsTest.java
+++ b/study/src/test/java/reflection/ReflectionsTest.java
@@ -1,18 +1,36 @@
 package reflection;
 
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reflection.annotation.Controller;
+import reflection.annotation.Repository;
+import reflection.annotation.Service;
 
 class ReflectionsTest {
 
     private static final Logger log = LoggerFactory.getLogger(ReflectionsTest.class);
 
     @Test
-    void showAnnotationClass() throws Exception {
+    void showAnnotationClass() {
         Reflections reflections = new Reflections("reflection.examples");
 
-        // TODO 클래스 레벨에 @Controller, @Service, @Repository 애노테이션이 설정되어 모든 클래스 찾아 로그로 출력한다.
+        Set<Class<?>> controllerClasses = reflections.getTypesAnnotatedWith(Controller.class);
+        Set<Class<?>> serviceClasses = reflections.getTypesAnnotatedWith(Service.class);
+        Set<Class<?>> repositoryClasses = reflections.getTypesAnnotatedWith(Repository.class);
+
+        controllerClasses.forEach(
+                controller -> log.info("controller class name = {}", controller.getName())
+        );
+
+        serviceClasses.forEach(
+                service -> log.info("service class name = {}", service.getName())
+        );
+
+        repositoryClasses.forEach(
+                repository -> log.info("repository class name = {}", repository.getName())
+        );
     }
 }

--- a/study/src/test/java/servlet/com/example/ServletTest.java
+++ b/study/src/test/java/servlet/com/example/ServletTest.java
@@ -28,7 +28,12 @@ class ServletTest {
 
         // expected를 0이 아닌 올바른 값으로 바꿔보자.
         // 예상한 결과가 나왔는가? 왜 이런 결과가 나왔을까?
-        assertThat(Integer.parseInt(response.body())).isEqualTo(0);
+
+        /**
+         * 서블릿 내에서 인스턴스 변수로 두고 있기 때문에
+         * 세번의 요청이 값을 세번 증가시켜서 3을 반환한다.
+         */
+        assertThat(Integer.parseInt(response.body())).isEqualTo(3);
     }
 
     @Test
@@ -43,6 +48,11 @@ class ServletTest {
         HttpUtils.send(PATH);
         final var response = HttpUtils.send(PATH);
 
+        /**
+         * 여러 스레드가 /local-counter 서블릿에 접근을 하더라도
+         * 메소드 내 로컬 변수라서 공유되지 않아 1을 반환한다.
+         */
+
         // 톰캣 서버 종료
         tomcatStarter.stop();
 
@@ -50,6 +60,6 @@ class ServletTest {
 
         // expected를 0이 아닌 올바른 값으로 바꿔보자.
         // 예상한 결과가 나왔는가? 왜 이런 결과가 나왔을까?
-        assertThat(Integer.parseInt(response.body())).isEqualTo(0);
+        assertThat(Integer.parseInt(response.body())).isEqualTo(1);
     }
 }


### PR DESCRIPTION
안녕하세요 달리 🥳
리뷰이로 뵙게되었네용 반갑습니다!!

아래 부분은 이번에 AnnotationHandlerMapping 클래스를 구현하면서 고민을 많이 했던 부분입니다.

HandlerExecution 클래스를 보면
```java
public static HandlerExecution of(final Class<?> executor, final Method handlerMethod) throws Exception {
    return new HandlerExecution(executor.getConstructor().newInstance(), handlerMethod);
}
```
정적 팩토리 메소드에서 ```Class<?> executor``` 를 받아서 Instance Object 를 바로 만들어 주게 되는데요.
이 Object 객체를 handle 메소드가 호출할 때 만드는 것이 더 나을지 객체 생성부터 바로 만들어주는게 나을지 고민하다가 객체 생성 시점에 바로 만들어 주는게 낫겠다고 판단하였습니다.

여기서 달리는 어떻게 하셨는지? 아니면 어떻게 구현할 예정이신지 달리의 생각이 궁금합니다!!!

그리고 Servlet 학습 테스트를 진행하면서 ```destroy()``` 는 언제 호출이 될지 궁금해서 찾아보았습니다.
GenericServlet 클래스 destroy 메소드 설명에는

> Called by the servlet container to indicate to a servlet that the servlet is being taken out of service. See
> 서블릿이 서비스에서 제외됨을 서블릿에 알리기 위해 서블릿 컨테이너에 의해 호출됩니다.

Servlet 인터페이스 destroy 메소드 설명에는

>Called by the servlet container to indicate to a servlet that the servlet is being taken out of service. This
     * method is only called once all threads within the servlet's <code>service</code> method have exited or after a
     * timeout period has passed. After the servlet container calls this method, it will not call the
     * <code>service</code> method again on this servlet.
>서블릿이 서비스에서 제외됨을 서블릿에 알리기 위해 서블릿 컨테이너에 의해 호출됩니다. 이 메소드는 서블릿의 service 메소드 내의 모든 스레드가 종료되거나 제한 시간이 경과한 후에만 호출됩니다. 서블릿 컨테이너가 이 메소드를 호출한 후에는 이 서블릿에서 service 메소드를 다시 호출하지 않습니다.

먼저 3개의 스레드가 요청을 보낸다고 가정을 해보겠습니다.
처음에 이해한 부분은
- 서블릿이 처음에 init 되고 3개의 스레드가 service 를 호출하게 됩니다.
- 모든 스레드가 호출한 service 가 끝나면 destroy 가 자동적으로 호출됩니다.
- 마지막으로 destroy 가 호출된다면 만들어진 서블릿 객체는 자동적으로 소멸된다고 이해했습니다.

하지만 고민을 더 하다보니 위 방식대로 흘러가면
모든 요청이 끝나고 요청하고 반복하다 보면 쓸데없이 객체가 생성되고 사라진다고 생각합니다.

- GenericServlet 클래스에서의 설명을 보면 컨테이너에 의해서 호출된다고 합니다.
- 그러면 호출 시점은 언제일까 로그를 봤을 때? ```tomcatStarter.stop();``` 호출 되었을 때 destroy 가 되는 걸 확인했습니다.

결론으로 넘어가자면, 톰캣이 종료가 되어야지만 서블릿이 destroy 가 된다고 생각하는데 달리 의견이 궁금합니다!